### PR TITLE
[FIX] no caching -> cache forever

### DIFF
--- a/app/code/local/Scandi/MenuManager/Block/Menu.php
+++ b/app/code/local/Scandi/MenuManager/Block/Menu.php
@@ -344,7 +344,7 @@ class Scandi_MenuManager_Block_Menu extends Mage_Core_Block_Template
      */
     public function getCacheLifetime()
     {
-        return null;
+        return false;
     }
 
     /**


### PR DESCRIPTION
I see no valid reason to disable caching completely.
The block already implemented all the necessary methods for proper caching (getCacheTags, getCacheKeyInfo), just getCacheLifetime was bad.
Using "null" for cache-lifetime disables the block-cache. Instead, when using "false", means "cache forever" until an menu/menu-item changes and/or the whole Magento cache is flushed.